### PR TITLE
optimize queries

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -170,7 +170,7 @@ export class TldrawApp {
 
 	async preload(initialUserData: TlaUser) {
 		let didCreate = false
-		await this.userQuery().preload({ ttl: 'forever' }).complete
+		await this.userQuery().preload({ ttl: '2d' }).complete
 		await this.changesFlushed
 		if (!this.user$.get()) {
 			didCreate = true
@@ -184,7 +184,7 @@ export class TldrawApp {
 		if (!this.user$.get()) {
 			throw Error('could not create user')
 		}
-		await this.fileStatesQuery().preload({ ttl: 'forever' }).complete
+		await this.fileStatesQuery().preload({ ttl: '2d' }).complete
 		return didCreate
 	}
 

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -81,7 +81,6 @@ export class TldrawApp {
 	readonly z: ZeroPolyfill | Zero<TlaSchema>
 
 	private readonly user$: Signal<TlaUser | undefined>
-	private readonly files$: Signal<TlaFile[]>
 	private readonly fileStates$: Signal<(TlaFileState & { file: TlaFile })[]>
 
 	private readonly abortController = new AbortController()
@@ -157,23 +156,21 @@ export class TldrawApp {
 					trackEvent,
 				})
 
-		this.user$ = this.signalizeQuery(
-			'user signal',
-			this.z.query.user.where('id', this.userId).one()
-		)
-		this.files$ = this.signalizeQuery(
-			'files signal',
-			this.z.query.file.where('isDeleted', '=', false)
-		)
-		this.fileStates$ = this.signalizeQuery(
-			'file states signal',
-			this.z.query.file_state.where('userId', this.userId).related('file', (q: any) => q.one())
-		)
+		this.user$ = this.signalizeQuery('user signal', this.userQuery())
+		this.fileStates$ = this.signalizeQuery('file states signal', this.fileStatesQuery())
+	}
+
+	private userQuery() {
+		return this.z.query.user.where('id', this.userId).one()
+	}
+
+	private fileStatesQuery() {
+		return this.z.query.file_state.where('userId', this.userId).related('file', (q: any) => q.one())
 	}
 
 	async preload(initialUserData: TlaUser) {
 		let didCreate = false
-		await this.z.query.user.where('id', this.userId).preload().complete
+		await this.userQuery().preload({ ttl: 'forever' }).complete
 		await this.changesFlushed
 		if (!this.user$.get()) {
 			didCreate = true
@@ -187,8 +184,7 @@ export class TldrawApp {
 		if (!this.user$.get()) {
 			throw Error('could not create user')
 		}
-		await this.z.query.file_state.where('userId', this.userId).preload().complete
-		await this.z.query.file.where('ownerId', this.userId).preload().complete
+		await this.fileStatesQuery().preload({ ttl: 'forever' }).complete
 		return didCreate
 	}
 
@@ -288,8 +284,9 @@ export class TldrawApp {
 		},
 	})
 
+	@computed
 	getUserOwnFiles() {
-		return this.files$.get()
+		return this.getUserFileStates().map((f) => f.file)
 	}
 
 	getUserFileStates() {


### PR DESCRIPTION
Reduces initial query processing time from 638ms to 16ms.  Benchmarked on a database with 70k file rows and 140k file state rows, on my machine with a Apple M1 Max and 64GB of Ram.   

The existing file based query with permissions looks like:
```
this.z.query.file.where(({and, or, cmp}) => or(
  and(cmp('isDeleted', false), cmp('ownerId', auth.sub)), 
  and(cmp('isDeleted', false), cmp('shared', true), exists('states', q => q.where('userId', auth.sub))), 
));
```

This is slow because of the exists.  Exists is currently always implemented as a left join, and so we left join all file rows which are ` cmp('ownerId', auth.sub)` OR `cmp('shared', true)`, yielding O(total-number-of-shared-files).

If my understanding of the schema design is correct, there is a fileState row with the user's userId for every file to be displayed in the left nav (those owned by the user, and those shared with the user that the user has visited).  Thus we can get all the files to display to the user with a query starting from fileState.where('userID', userId).  In fact this query is already being done.  This approach is currently much more efficient. 


Existing file based query
```
greg zero-cache [grgbkr/perf]$ npx analyze-query --schema=../../../packages/dotcom-shared/src/tlaSchema.ts --query="file.where(({and,cmp,exists,or})=>or(and(cmp('isDeleted',false),cmp('ownerId','user_d0b77a968a3646288540')),and(cmp('isDeleted',false),cmp('shared',true),exists('states',(q)=>q.where('userId','user_d0b77a968a3646288540').orderBy('userId','asc').orderBy('fileId','asc'))))).orderBy('id','asc').orderBy('ownerId','asc').orderBy('publishedSlug','asc')"
[dotenvx@1.39.1] injecting env (7) from .env
=== Query Stats: ===

file vended: [
  [
    'SELECT "id","name","ownerId","ownerName","ownerAvatar","thumbnail","shared","sharedLinkType","published","lastPublished","publishedSlug","createdAt","updatedAt","isEmpty","isDeleted","createSource" FROM "file" WHERE (("isDeleted" = ? AND "ownerId" = ?) OR ("isDeleted" = ? AND "shared" = ?)) ORDER BY "id" asc, "ownerId" asc, "publishedSlug" asc',
    34914
  ]
]
file_state vended: [
  [
    'SELECT "userId","fileId","firstVisitAt","lastEditAt","lastSessionState","lastVisitAt","isFileOwner","isPinned" FROM "file_state" WHERE "fileId" = ? AND "userId" = ? ORDER BY "userId" asc, "fileId" asc',
    2
  ]
]
total rows considered: 34916
time: 638.19ms ms


=== Query Plans: ===

query SELECT "id","name","ownerId","ownerName","ownerAvatar","thumbnail","shared","sharedLinkType","published","lastPublished","publishedSlug","createdAt","updatedAt","isEmpty","isDeleted","createSource" FROM "file" WHERE (("isDeleted" = ? AND "ownerId" = ?) OR ("isDeleted" = ? AND "shared" = ?)) ORDER BY "id" asc, "ownerId" asc, "publishedSlug" asc
MULTI-INDEX OR
INDEX 1
SEARCH file USING INDEX file_owner_index (ownerId=?)
INDEX 2
SEARCH file USING INDEX file_shared_index (shared=?)
USE TEMP B-TREE FOR ORDER BY


query SELECT "userId","fileId","firstVisitAt","lastEditAt","lastSessionState","lastVisitAt","isFileOwner","isPinned" FROM "file_state" WHERE "fileId" = ? AND "userId" = ? ORDER BY "userId" asc, "fileId" asc
SEARCH file_state USING INDEX file_state_pkey (fileId=? AND userId=?)
```

New file state based query
```
greg zero-cache [grgbkr/perf]$ npx analyze-query --schema=../../../packages/dotcom-shared/src/tlaSchema.ts --query="file_state.where('userId','user_d0b77a968a3646288540').related('file',(q)=>q.where(({and,cmp,exists,or})=>or(cmp('ownerId',null),and(cmp('shared',true),exists('states',(q)=>q.where('userId','user_d0b77a968a3646288540').orderBy('userId','asc').orderBy('fileId','asc'))))).orderBy('id','asc').orderBy('ownerId','asc').orderBy('publishedSlug','asc').limit(1)).orderBy('userId','asc').orderBy('fileId','asc')"
[dotenvx@1.39.1] injecting env (7) from .env
=== Query Stats: ===

file_state vended: [
  [
    'SELECT "userId","fileId","firstVisitAt","lastEditAt","lastSessionState","lastVisitAt","isFileOwner","isPinned" FROM "file_state" WHERE "userId" = ? ORDER BY "userId" asc, "fileId" asc',
    8
  ],
  [
    'SELECT "userId","fileId","firstVisitAt","lastEditAt","lastSessionState","lastVisitAt","isFileOwner","isPinned" FROM "file_state" WHERE "fileId" = ? AND "userId" = ? ORDER BY "userId" asc, "fileId" asc',
    3
  ]
]
file vended: [
  [
    'SELECT "id","name","ownerId","ownerName","ownerAvatar","thumbnail","shared","sharedLinkType","published","lastPublished","publishedSlug","createdAt","updatedAt","isEmpty","isDeleted","createSource" FROM "file" WHERE "id" = ? AND ("ownerId" = ? OR "shared" = ?) ORDER BY "id" asc, "ownerId" asc, "publishedSlug" asc',
    6
  ]
]
total rows considered: 17
time: 15.26ms ms


=== Query Plans: ===

query SELECT "userId","fileId","firstVisitAt","lastEditAt","lastSessionState","lastVisitAt","isFileOwner","isPinned" FROM "file_state" WHERE "userId" = ? ORDER BY "userId" asc, "fileId" asc
SCAN file_state USING INDEX file_state_pkey


query SELECT "userId","fileId","firstVisitAt","lastEditAt","lastSessionState","lastVisitAt","isFileOwner","isPinned" FROM "file_state" WHERE "fileId" = ? AND "userId" = ? ORDER BY "userId" asc, "fileId" asc
SEARCH file_state USING INDEX file_state_pkey (fileId=? AND userId=?)


query SELECT "id","name","ownerId","ownerName","ownerAvatar","thumbnail","shared","sharedLinkType","published","lastPublished","publishedSlug","createdAt","updatedAt","isEmpty","isDeleted","createSource" FROM "file" WHERE "id" = ? AND ("ownerId" = ? OR "shared" = ?) ORDER BY "id" asc, "ownerId" asc, "publishedSlug" asc
SEARCH file USING INDEX file_id_unique (id=?)
```